### PR TITLE
Multilevel logging extra APIs

### DIFF
--- a/rocsolver/clients/samples/example_basic.c
+++ b/rocsolver/clients/samples/example_basic.c
@@ -53,7 +53,7 @@ int main() {
   // initialization
   rocblas_handle handle;
   rocblas_create_handle(&handle);
-  rocsolver_logging_initialize(rocblas_layer_mode_none, 5);
+  rocsolver_create_logger();
 
   // calculate the sizes of our arrays
   size_t size_A = lda * (size_t)N;   // count of elements in matrix A
@@ -92,6 +92,6 @@ int main() {
   hipFree(dA);
   hipFree(dIpiv);
   free(hA);
-  rocsolver_logging_cleanup();
+  rocsolver_destroy_logger();
   rocblas_destroy_handle(handle);
 }

--- a/rocsolver/clients/samples/example_basic.cpp
+++ b/rocsolver/clients/samples/example_basic.cpp
@@ -52,7 +52,7 @@ int main() {
   // initialization
   rocblas_handle handle;
   rocblas_create_handle(&handle);
-  rocsolver_logging_initialize(rocblas_layer_mode_none, 5);
+  rocsolver_create_logger();
 
   // calculate the sizes of our arrays
   size_t size_A = size_t(lda) * N;          // count of elements in matrix A
@@ -89,6 +89,6 @@ int main() {
   // clean up
   hipFree(dA);
   hipFree(dIpiv);
-  rocsolver_logging_cleanup();
+  rocsolver_destroy_logger();
   rocblas_destroy_handle(handle);
 }

--- a/rocsolver/clients/samples/example_hmm.c
+++ b/rocsolver/clients/samples/example_hmm.c
@@ -55,7 +55,7 @@ int main() {
   // initialization
   rocblas_handle handle;
   rocblas_create_handle(&handle);
-  rocsolver_logging_initialize(rocblas_layer_mode_none, 5);
+  rocsolver_create_logger();
 
   // calculate the sizes of our arrays
   size_t size_piv = (M < N) ? M : N; // count of Householder scalars
@@ -97,6 +97,6 @@ int main() {
   hipFree(A);
   hipFree(ipiv);
   hipFree(work);
-  rocsolver_logging_cleanup();
+  rocsolver_destroy_logger();
   rocblas_destroy_handle(handle);
 }

--- a/rocsolver/library/include/rocsolver-functions.h
+++ b/rocsolver/library/include/rocsolver-functions.h
@@ -22,8 +22,9 @@ extern "C" {
  * ===========================================================================
  */
 
-/*! \brief Query the library version.
+/*! \brief GET_VERSION_STRING Queries the library version.
 
+    \details
     @param[out]
     buf         A buffer that the version string will be written into.
     @param[in]
@@ -32,34 +33,59 @@ extern "C" {
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_get_version_string(char* buf, size_t len);
 
+
 /*
  * ===========================================================================
  *      Multi-level logging
  * ===========================================================================
  */
 
-/*! \brief Initialize multi-level logging set-up for rocSOLVER.
+/*! \brief LOGGING_INITIALIZE re-initializes the multi-level rocSOLVER logger to the specified layer_mode and levels.
 
+    \details
     @param[in]
     layer_mode      rocblas_layer_mode.\n
-                    The default logging layer mode. Can be overridden using
-                    environment variable ROCSOLVER_LAYER.
+                    Specifies the logging mode.
     @param[in]
     max_levels      rocblas_int. max_levels >= 1.\n
-                    The default maximum depth at which nested function calls
-                    will appear in the log. Can be overridden using environment
-                    variable ROCSOLVER_LEVELS.
+                    Specifies the maximum depth at which nested function calls
+                    will appear in the log. 
  ******************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_logging_initialize(const rocblas_layer_mode layer_mode,
                                                              const rocblas_int max_levels);
 
-/*! \brief Clean up multi-level logging set-up for rocSOLVER and, if applicable
-    print the profile logging results.
+
+/*! \brief LOGGING_CLEANUP cleans up the multi-level rocSOLVER logger. 
+
+    \details
+    This function prints the profile logging results, if applicable, and then reset the logger to the
+    default mode (no logging).
  ******************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_logging_cleanup(void);
+
+
+/*! \brief CREATE_LOGGER creates a multi-level rocSOLVER logger.
+
+    \details
+    Creates a rocSOLVER logger and initializes it to the default mode (no logging and one level depth).
+    Default mode can be overridden by using the environment variables ROCSOLVER_LAYER and ROCSOLVER_LEVELS.
+
+    This function also sets the streams where the log results will be outputted. The default is STDERR for 
+    all the modes. This default can also be overridden using the environment variable ROCSOLVER_LOG_PATH, or
+    specifically ROCSOLVER_LOG_TRACE_PATH, ROCSOLVER_LOG_BENCH_PATH, and/or ROCSOLVER_LOG_PROFILE_PATH.
+******************************************************************************/
+
 ROCSOLVER_EXPORT rocblas_status rocsolver_create_logger(void);
+
+
+/*! \brief DESTROY_LOGGER destroys the multi-level rocSOLVER logger.
+
+    \details
+    If applicable, this function also prints the profile logging results before destroying the logger.
+*****************************************************************************/
+
 ROCSOLVER_EXPORT rocblas_status rocsolver_destroy_logger(void);
 
 /*

--- a/rocsolver/library/include/rocsolver-functions.h
+++ b/rocsolver/library/include/rocsolver-functions.h
@@ -59,6 +59,8 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_logging_initialize(const rocblas_layer
  ******************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_logging_cleanup(void);
+ROCSOLVER_EXPORT rocblas_status rocsolver_create_logger(void);
+ROCSOLVER_EXPORT rocblas_status rocsolver_destroy_logger(void);
 
 /*
  * ===========================================================================

--- a/rocsolver/library/include/rocsolver-functions.h
+++ b/rocsolver/library/include/rocsolver-functions.h
@@ -61,9 +61,13 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_logging_initialize(const rocblas_layer
     \details
     This function prints the profile logging results, if applicable, and then reset the logger to the
     default mode (no logging).
+
+    @param[in]
+    clean_profile   boolean.\n
+                    Specifies whether the profile record will be erased after printed.
  ******************************************************************************/
 
-ROCSOLVER_EXPORT rocblas_status rocsolver_logging_cleanup(void);
+ROCSOLVER_EXPORT rocblas_status rocsolver_logging_cleanup(bool clean_profile);
 
 
 /*! \brief CREATE_LOGGER creates a multi-level rocSOLVER logger.

--- a/rocsolver/library/src/include/rocsolver_logger.hpp
+++ b/rocsolver/library/src/include/rocsolver_logger.hpp
@@ -124,9 +124,6 @@ private:
     template <typename T, typename... Ts>
     void log_bench(int level, const char* func_prefix, const char* func_name, Ts... args)
     {
-        for(int i = 0; i < level - 1; i++)
-            *bench_os << "    ";
-
         *bench_os << "./rocsolver-bench -f " << func_name << " -r " << get_precision<T>() << ' ';
         print_pairs(*bench_os, " ", args...);
         *bench_os << std::endl;
@@ -192,8 +189,8 @@ public:
         if(layer_mode & rocblas_layer_mode_log_bench)
             log_bench<T>(entry.level, func_prefix, func_name, args...);
 
-        if(trace_os)
-            *trace_os << "------- ENTER " << entry.name << " -------\n";
+        if(layer_mode & rocblas_layer_mode_log_trace)
+            *trace_os << "------- ENTER " << entry.name << " trace tree" << " -------\n";
     }
 
     // logging function to be called before exiting a top-level (i.e. impl) function
@@ -205,8 +202,8 @@ public:
         rocsolver_logger::_mutex.unlock();
         ROCSOLVER_ASSUME(entry.level == 0);
 
-        if(trace_os)
-            *trace_os << "-------  EXIT " << entry.name << " -------\n" << std::endl;
+        if(layer_mode & rocblas_layer_mode_log_trace)
+            *trace_os << "------- EXIT " << entry.name << " trace tree" << " -------\n" << std::endl;
     }
 
     // logging function to be called upon entering a sub-level (i.e. template) function

--- a/rocsolver/library/src/include/rocsolver_logger.hpp
+++ b/rocsolver/library/src/include/rocsolver_logger.hpp
@@ -252,7 +252,7 @@ public:
 
     friend rocblas_status rocsolver_logging_initialize(const rocblas_layer_mode layer_mode,
                                                        const rocblas_int max_levels);
-    friend rocblas_status rocsolver_logging_cleanup(void);
+    friend rocblas_status rocsolver_logging_cleanup(bool clean_profile);
     friend rocblas_status rocsolver_create_logger(void);
     friend rocblas_status rocsolver_destroy_logger(void);
 };

--- a/rocsolver/library/src/include/rocsolver_logger.hpp
+++ b/rocsolver/library/src/include/rocsolver_logger.hpp
@@ -256,4 +256,6 @@ public:
     friend rocblas_status rocsolver_logging_initialize(const rocblas_layer_mode layer_mode,
                                                        const rocblas_int max_levels);
     friend rocblas_status rocsolver_logging_cleanup(void);
+    friend rocblas_status rocsolver_create_logger(void);
+    friend rocblas_status rocsolver_destroy_logger(void);
 };

--- a/rocsolver/library/src/rocsolver_logger.cpp
+++ b/rocsolver/library/src/rocsolver_logger.cpp
@@ -151,7 +151,7 @@ rocblas_status rocsolver_logging_initialize(const rocblas_layer_mode layer_mode,
     return rocblas_status_success;
 }
 
-rocblas_status rocsolver_logging_cleanup()
+rocblas_status rocsolver_logging_cleanup(bool clean_profile)
 {
     rocsolver_logger::_mutex.lock();
 
@@ -185,7 +185,7 @@ rocblas_status rocsolver_logging_cleanup()
     // reset to no logging and clear profile info
     logger->max_levels = 1;
     logger->layer_mode = rocblas_layer_mode_none;
-    logger->profile.clear();
+    if(clean_profile) logger->profile.clear();
 
     rocsolver_logger::_mutex.unlock();
 
@@ -195,7 +195,7 @@ rocblas_status rocsolver_logging_cleanup()
 rocblas_status rocsolver_destroy_logger()
 {
     // first cleanup in case there is profile to print
-    rocsolver_logging_cleanup();
+    rocsolver_logging_cleanup(true);
     
     // then delete the logger if any 
     rocsolver_logger::_mutex.lock();

--- a/rocsolver/library/src/rocsolver_logger.cpp
+++ b/rocsolver/library/src/rocsolver_logger.cpp
@@ -89,8 +89,12 @@ rocblas_status rocsolver_create_logger()
 {
     rocsolver_logger::_mutex.lock();
 
-    if(rocsolver_logger::_instance != nullptr)
+    // if there is no logger, create one and:
+    if(rocsolver_logger::_instance != nullptr) 
+    {
+        rocsolver_logger::_mutex.unlock(); 
         return rocblas_status_internal_error;
+    }
 
     auto logger = rocsolver_logger::_instance = new rocsolver_logger();
 
@@ -108,44 +112,42 @@ rocblas_status rocsolver_create_logger()
     else
         logger->max_levels = 1;
 
+    // create output streams (specified by env variables or default to stderr)
+    logger->trace_os = logger->open_log_stream("ROCSOLVER_LOG_TRACE_PATH");
+    logger->bench_os = logger->open_log_stream("ROCSOLVER_LOG_BENCH_PATH");
+    logger->profile_os = logger->open_log_stream("ROCSOLVER_LOG_PROFILE_PATH");
+
+    rocsolver_logger::_mutex.unlock();
+
     return rocblas_status_success;
 }
 
 rocblas_status rocsolver_logging_initialize(const rocblas_layer_mode layer_mode,
                                             const rocblas_int max_levels)
 {
-//    if(rocsolver_logger::_instance != nullptr)
+    rocsolver_logger::_mutex.lock();
+ 
+    // if there is an active logger:   
     if(rocsolver_logger::_instance == nullptr)
+    {
+        rocsolver_logger::_mutex.unlock();
         return rocblas_status_internal_error;
+    }
     if(max_levels < 1)
+    {
+        rocsolver_logger::_mutex.unlock();
         return rocblas_status_invalid_value;
+    }
 
-//    auto logger = rocsolver_logger::_instance = new rocsolver_logger();
     auto logger = rocsolver_logger::_instance;
 
-    // set layer_mode from value of environment variable ROCSOLVER_LAYER
-//    const char* str_layer_mode = getenv("ROCSOLVER_LAYER");
-//    if(str_layer_mode)
-//        logger->layer_mode = static_cast<rocblas_layer_mode>(strtol(str_layer_mode, 0, 0));
-//    else
+    // change to user specified mode and levels. 
+    // output streams remain the same defined at logger creation 
     logger->layer_mode = layer_mode;
-
-    // set max_levels from value of environment variable ROCSOLVER_LEVELS
-//    const char* str_max_level = getenv("ROCSOLVER_LEVELS");
-//    if(str_max_level)
-//        logger->max_levels = static_cast<int>(strtol(str_max_level, 0, 0));
-//    else
     logger->max_levels = max_levels;
 
-    // create output streams
-    if(logger->layer_mode & rocblas_layer_mode_log_trace)
-        logger->trace_os = logger->open_log_stream("ROCSOLVER_LOG_TRACE_PATH");
-    if(logger->layer_mode & rocblas_layer_mode_log_bench)
-        logger->bench_os = logger->open_log_stream("ROCSOLVER_LOG_BENCH_PATH");
-    if(logger->layer_mode & rocblas_layer_mode_log_profile)
-        logger->profile_os = logger->open_log_stream("ROCSOLVER_LOG_PROFILE_PATH");
-
     rocsolver_logger::_mutex.unlock();
+
     return rocblas_status_success;
 }
 
@@ -153,8 +155,12 @@ rocblas_status rocsolver_logging_cleanup()
 {
     rocsolver_logger::_mutex.lock();
 
+    // if there is an active logger:
     if(rocsolver_logger::_instance == nullptr)
+    {
+        rocsolver_logger::_mutex.unlock();
         return rocblas_status_internal_error;
+    }
 
     auto logger = rocsolver_logger::_instance;
 
@@ -176,25 +182,35 @@ rocblas_status rocsolver_logging_cleanup()
         *logger->profile_os << std::endl;
     }
 
-//    delete logger;
-//    logger = nullptr;
-
+    // reset to no logging and clear profile info
     logger->max_levels = 1;
     logger->layer_mode = rocblas_layer_mode_none;
+    logger->profile.clear();
 
     rocsolver_logger::_mutex.unlock();
+
     return rocblas_status_success;
 }
 
 rocblas_status rocsolver_destroy_logger()
 {
-    if(rocsolver_logger::_instance == nullptr)
-        return rocblas_status_internal_error;
-
+    // first cleanup in case there is profile to print
     rocsolver_logging_cleanup();
+    
+    // then delete the logger if any 
+    rocsolver_logger::_mutex.lock();
+    
+    if(rocsolver_logger::_instance == nullptr)
+    {
+        rocsolver_logger::_mutex.unlock();
+        return rocblas_status_internal_error;
+    }
+    
     delete rocsolver_logger::_instance;
     rocsolver_logger::_instance = nullptr;
 
+    rocsolver_logger::_mutex.unlock();
+    
     return rocblas_status_success;    
 }
 


### PR DESCRIPTION
I would like to separate the logger creation/destruction from the logger manipulation (initialization and cleanup). For that I added two new APIs: rocsolver_create_logger and rocsolver_destroy_logger, and modified a bit the behavior of rocsolver_logging_cleanup and rocsolver_logging_initialize.

An application can be logged by simply having rocsolver_create_logger and rocsolver_destroy_logger at the beginning and the end of the code, and using the environment variables. Additionally, we can have more advanced/versatile logging by using the other two APIs within the code: the logging mode can be changed on the fly, or stopped for some parts of the code, we can print intermediate profile results, etc.... 