### PR TITLE
Combine masked_copymat and copy_mat

### DIFF
--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -152,7 +152,7 @@ void local_gemm(rocblas_handle handle,
     rocblas_get_stream(handle, &stream);
     rocblas_int blocks = (n - 1) / 32 + 1;
     hipLaunchKernelGGL(copy_mat<T>, dim3(blocks, blocks, batch_count), dim3(32, 32), 0, stream,
-                       copymat_from_buffer, n, n, A, shiftA, lda, strideA, temp, rocblas_fill_full);
+                       copymat_from_buffer, n, n, A, shiftA, lda, strideA, temp);
 
     rocblas_set_pointer_mode(handle, old_mode);
 }

--- a/library/src/lapack/roclapack_gels.hpp
+++ b/library/src/lapack/roclapack_gels.hpp
@@ -232,9 +232,9 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                info);
 
             // save elements of B that will be overwritten by TRSM for cases where info is nonzero
-            hipLaunchKernelGGL((masked_copymat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
+            hipLaunchKernelGGL((copy_mat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
                                dim3(32, 32), 0, stream, copymat_to_buffer, n, nrhs, B, shiftB, ldb,
-                               strideB, ipiv_savedB, info);
+                               strideB, ipiv_savedB, info_mask(info));
 
             // solve RX = Q'B, overwriting B with X
             rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, rocblas_fill_upper,
@@ -244,9 +244,9 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                          diag_trfac_invA, trfact_workTrmm_invA_arr);
 
             // restore elements of B that were overwritten by TRSM in cases where info is nonzero
-            hipLaunchKernelGGL((masked_copymat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
+            hipLaunchKernelGGL((copy_mat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
                                dim3(32, 32), 0, stream, copymat_from_buffer, n, nrhs, B, shiftB,
-                               ldb, strideB, ipiv_savedB, info);
+                               ldb, strideB, ipiv_savedB, info_mask(info));
         }
         else
         {
@@ -256,9 +256,9 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                info);
 
             // save elements of B that will be overwritten by TRSM for cases where info is nonzero
-            hipLaunchKernelGGL((masked_copymat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
+            hipLaunchKernelGGL((copy_mat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
                                dim3(32, 32), 0, stream, copymat_to_buffer, n, nrhs, B, shiftB, ldb,
-                               strideB, ipiv_savedB, info);
+                               strideB, ipiv_savedB, info_mask(info));
 
             // solve R'Y = B overwriting B with Y (here Y = Q'X)
             rocblasCall_trsm<BATCHED, T>(
@@ -279,9 +279,9 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                 (T**)trfact_workTrmm_invA_arr);
 
             // restore elements of B that were overwritten by TRSM and ORMQR/UNMQR in cases where info is nonzero
-            hipLaunchKernelGGL((masked_copymat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
+            hipLaunchKernelGGL((copy_mat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
                                dim3(32, 32), 0, stream, copymat_from_buffer, n, nrhs, B, shiftB,
-                               ldb, strideB, ipiv_savedB, info);
+                               ldb, strideB, ipiv_savedB, info_mask(info));
         }
     }
     else
@@ -299,9 +299,9 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                info);
 
             // save elements of B that will be overwritten by TRSM for cases where info is nonzero
-            hipLaunchKernelGGL((masked_copymat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
+            hipLaunchKernelGGL((copy_mat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
                                dim3(32, 32), 0, stream, copymat_to_buffer, m, nrhs, B, shiftB, ldb,
-                               strideB, ipiv_savedB, info);
+                               strideB, ipiv_savedB, info_mask(info));
 
             // solve LY = B overwriting B with Y (here Y = QX)
             rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, rocblas_fill_lower,
@@ -322,9 +322,9 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                 (T**)trfact_workTrmm_invA_arr);
 
             // restore elements of B that were overwritten by TRSM and ORMLQ/UNMLQ in cases where info is nonzero
-            hipLaunchKernelGGL((masked_copymat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
+            hipLaunchKernelGGL((copy_mat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
                                dim3(32, 32), 0, stream, copymat_from_buffer, m, nrhs, B, shiftB,
-                               ldb, strideB, ipiv_savedB, info);
+                               ldb, strideB, ipiv_savedB, info_mask(info));
         }
         else
         {
@@ -340,9 +340,9 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                info);
 
             // save elements of B that will be overwritten by TRSM for cases where info is nonzero
-            hipLaunchKernelGGL((masked_copymat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
+            hipLaunchKernelGGL((copy_mat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
                                dim3(32, 32), 0, stream, copymat_to_buffer, m, nrhs, B, shiftB, ldb,
-                               strideB, ipiv_savedB, info);
+                               strideB, ipiv_savedB, info_mask(info));
 
             // solve L'X = QB, overwriting B with X
             rocblasCall_trsm<BATCHED, T>(
@@ -352,9 +352,9 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                 workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
 
             // restore elements of B that were overwritten by TRSM in cases where info is nonzero
-            hipLaunchKernelGGL((masked_copymat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
+            hipLaunchKernelGGL((copy_mat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
                                dim3(32, 32), 0, stream, copymat_from_buffer, m, nrhs, B, shiftB,
-                               ldb, strideB, ipiv_savedB, info);
+                               ldb, strideB, ipiv_savedB, info_mask(info));
         }
     }
 

--- a/library/src/lapack/roclapack_gesv.hpp
+++ b/library/src/lapack/roclapack_gesv.hpp
@@ -153,9 +153,9 @@ rocblas_status rocsolver_gesv_template(rocblas_handle handle,
         optim_mem);
 
     // save elements of B that will be overwritten by GETRS for cases where info is nonzero
-    hipLaunchKernelGGL(masked_copymat<T>, dim3(copyblocksx, copyblocksy, batch_count), dim3(32, 32),
+    hipLaunchKernelGGL(copy_mat<T>, dim3(copyblocksx, copyblocksy, batch_count), dim3(32, 32),
                        0, stream, copymat_to_buffer, n, nrhs, B, shiftB, ldb, strideB, (T*)work,
-                       info);
+                       info_mask(info));
 
     // solve AX = B, overwriting B with X
     rocsolver_getrs_template<BATCHED, T>(handle, rocblas_operation_none, n, nrhs, A, shiftA, lda,
@@ -163,9 +163,9 @@ rocblas_status rocsolver_gesv_template(rocblas_handle handle,
                                          batch_count, work1, work2, work3, work4, optim_mem);
 
     // restore elements of B that were overwritten by GETRS in cases where info is nonzero
-    hipLaunchKernelGGL(masked_copymat<T>, dim3(copyblocksx, copyblocksy, batch_count), dim3(32, 32),
+    hipLaunchKernelGGL(copy_mat<T>, dim3(copyblocksx, copyblocksy, batch_count), dim3(32, 32),
                        0, stream, copymat_from_buffer, n, nrhs, B, shiftB, ldb, strideB, (T*)work,
-                       info);
+                       info_mask(info));
 
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_gesv_outofplace.hpp
+++ b/library/src/lapack/roclapack_gesv_outofplace.hpp
@@ -164,8 +164,8 @@ rocblas_status rocsolver_gesv_outofplace_template(rocblas_handle handle,
                                          batch_count, work1, work2, work3, work4, optim_mem);
 
     // recopy B to X in cases where info is nonzero
-    hipLaunchKernelGGL(masked_copymat<T>, dim3(copyblocksx, copyblocksy, batch_count), dim3(32, 32),
-                       0, stream, n, nrhs, B, shiftB, ldb, strideB, X, shiftX, ldx, strideX, info);
+    hipLaunchKernelGGL(copy_mat<T>, dim3(copyblocksx, copyblocksy, batch_count), dim3(32, 32),
+                       0, stream, n, nrhs, B, shiftB, ldb, strideB, X, shiftX, ldx, strideX, info_mask(info));
 
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_gesvd.hpp
+++ b/library/src/lapack/roclapack_gesvd.hpp
@@ -555,7 +555,7 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
             // copy the triangular part to be used in the bidiagonalization
             hipLaunchKernelGGL(copy_mat<T>, dim3(blocks_k, blocks_k, batch_count),
                                dim3(thread_count, thread_count, 1), 0, stream, k, k, A, shiftA, lda,
-                               strideA, bufferT, shiftT, ldt, strideT, uplo);
+                               strideA, bufferT, shiftT, ldt, strideT, no_mask{}, uplo);
 
             //*** STAGE 2: generate orthonormal/unitary matrix from row/column compression ***//
             if(leadvA)
@@ -704,7 +704,7 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
                 // copy the triangular part
                 hipLaunchKernelGGL(copy_mat<T>, dim3(blocks_k, blocks_k, batch_count),
                                    dim3(thread_count, thread_count, 1), 0, stream, k, k, A, shiftA,
-                                   lda, strideA, bufferT, shiftT, ldt, strideT, uplo);
+                                   lda, strideA, bufferT, shiftT, ldt, strideT, no_mask{}, uplo);
 
             //*** STAGE 2: generate orthonormal/unitary matrix from row/column compression ***//
             if(leadvO)

--- a/library/src/lapack/roclapack_posv.hpp
+++ b/library/src/lapack/roclapack_posv.hpp
@@ -147,9 +147,9 @@ rocblas_status rocsolver_posv_template(rocblas_handle handle,
                                             pivots_savedB, iinfo, optim_mem);
 
     // save elements of B that will be overwritten by POTRS for cases where info is nonzero
-    hipLaunchKernelGGL((masked_copymat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
+    hipLaunchKernelGGL((copy_mat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
                        dim3(32, 32), 0, stream, copymat_to_buffer, n, nrhs, B, shiftB, ldb, strideB,
-                       pivots_savedB, info);
+                       pivots_savedB, info_mask(info));
 
     // solve AX = B, overwriting B with X
     rocsolver_potrs_template<BATCHED, T>(handle, uplo, n, nrhs, A, shiftA, lda, strideA, B, shiftB,
@@ -157,9 +157,9 @@ rocblas_status rocsolver_posv_template(rocblas_handle handle,
                                          optim_mem);
 
     // restore elements of B that were overwritten by POTRS in cases where info is nonzero
-    hipLaunchKernelGGL((masked_copymat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
+    hipLaunchKernelGGL((copy_mat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),
                        dim3(32, 32), 0, stream, copymat_from_buffer, n, nrhs, B, shiftB, ldb,
-                       strideB, pivots_savedB, info);
+                       strideB, pivots_savedB, info_mask(info));
 
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_trtri.hpp
+++ b/library/src/lapack/roclapack_trtri.hpp
@@ -495,8 +495,8 @@ rocblas_status rocsolver_trtri_template(rocblas_handle handle,
     if(diag == rocblas_diagonal_non_unit && blk > 0)
     {
         // save copy of A to restore it in cases where info is nonzero
-        hipLaunchKernelGGL((masked_copymat<T>), dim3(blocks, blocks, batch_count), dim3(32, 32), 0,
-                           stream, copymat_to_buffer, n, n, A, shiftA, lda, strideA, tmpcopy, info);
+        hipLaunchKernelGGL((copy_mat<T>), dim3(blocks, blocks, batch_count), dim3(32, 32), 0,
+                           stream, copymat_to_buffer, n, n, A, shiftA, lda, strideA, tmpcopy, info_mask(info));
     }
 
     if(blk == 0)
@@ -507,9 +507,9 @@ rocblas_status rocsolver_trtri_template(rocblas_handle handle,
                                                (T**)work2, workArr);
 
         // copy result to A if info is zero
-        hipLaunchKernelGGL((masked_copymat<T>), dim3(blocks, blocks, batch_count), dim3(32, 32), 0,
+        hipLaunchKernelGGL((copy_mat<T>), dim3(blocks, blocks, batch_count), dim3(32, 32), 0,
                            stream, copymat_from_buffer, n, n, A, shiftA, lda, strideA, tmpcopy,
-                           info, uplo, diag, true);
+                           info_mask(info, info_mask::negate), uplo, diag);
     }
 
     else if(blk == 1)
@@ -570,8 +570,8 @@ rocblas_status rocsolver_trtri_template(rocblas_handle handle,
     if(diag == rocblas_diagonal_non_unit && blk > 0)
     {
         // restore A in cases where info is nonzero
-        hipLaunchKernelGGL((masked_copymat<T>), dim3(blocks, blocks, batch_count), dim3(32, 32), 0,
-                           stream, copymat_from_buffer, n, n, A, shiftA, lda, strideA, tmpcopy, info);
+        hipLaunchKernelGGL((copy_mat<T>), dim3(blocks, blocks, batch_count), dim3(32, 32), 0,
+                           stream, copymat_from_buffer, n, n, A, shiftA, lda, strideA, tmpcopy, info_mask(info));
     }
 
     rocblas_set_pointer_mode(handle, old_mode);


### PR DESCRIPTION
I observed no significant performance differences between the existing and proposed solution in testing.

I also compared the negation via ternary and xor. It made no difference to performance, but the xor check was 3 fewer instructions. So, I figured might as well.