### PR TITLE
update Stein

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -326,6 +326,13 @@ try
             "                           Indicates how the right singular vectors are to be calculated and stored.\n"
             "                           ")
 
+        // stein options
+         ("nev",
+         value<rocblas_int>(),
+            "Number of eigenvectors to compute in a partial decomposition.\n"
+            "                           Only applicable to stein.\n"
+            "                           ")
+
         // trtri options
         ("diag",
          value<char>()->default_value('N'),

--- a/clients/gtest/stein_gtest.cpp
+++ b/clients/gtest/stein_gtest.cpp
@@ -11,11 +11,15 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef vector<int> stein_tuple;
+typedef std::tuple<vector<int>, int> stein_tuple;
 
 // each size_range vector is a {N, ldz}
 
-// case when N == 0 will also execute the bad arguments test
+// each vec_range is a {nev} 
+// Indicates the number of vectors to compute 
+// (vectors are always associated with the last nev eigenvalues)
+
+// case when N == 0 and nev == 5 will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
 // for checkin_lapack tests
@@ -26,21 +30,27 @@ const vector<vector<int>> matrix_size_range = {
     {-1, 1},
     {2, 1},
     // normal (valid) samples
-    {12, 12},
+    {15, 15},
     {20, 30},
     {35, 40}};
+const vector<int> vec_range = {5, 10, 15};
 
 // for daily_lapack tests
 const vector<vector<int>> large_matrix_size_range = {{192, 192}, {256, 270}, {300, 300}};
+const vector<int> large_vec_range = {25, 40, 65};
+
+
 
 Arguments stein_setup_arguments(stein_tuple tup)
 {
-    vector<int> size = tup;
-
     Arguments arg;
+    
+    vector<int> size = std::get<0>(tup);
+    rocblas_int nev = std::get<1>(tup);
 
     arg.set<rocblas_int>("n", size[0]);
     arg.set<rocblas_int>("ldz", size[1]);
+    arg.set<rocblas_int>("nev", nev);
 
     arg.timing = 0;
 
@@ -59,7 +69,7 @@ protected:
     {
         Arguments arg = stein_setup_arguments(GetParam());
 
-        if(arg.peek<rocblas_int>("n") == 0)
+        if(arg.peek<rocblas_int>("n") == 0 && arg.peek<rocblas_int>("nev") == 5)
             testing_stein_bad_arg<T>();
 
         testing_stein<T>(arg);
@@ -88,6 +98,8 @@ TEST_P(STEIN, __double_complex)
     run_tests<rocblas_double_complex>();
 }
 
-INSTANTIATE_TEST_SUITE_P(daily_lapack, STEIN, ValuesIn(large_matrix_size_range));
+INSTANTIATE_TEST_SUITE_P(daily_lapack, STEIN, 
+                        Combine(ValuesIn(large_matrix_size_range), ValuesIn(large_vec_range)));
 
-INSTANTIATE_TEST_SUITE_P(checkin_lapack, STEIN, ValuesIn(matrix_size_range));
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, STEIN, 
+                        Combine(ValuesIn(matrix_size_range), ValuesIn(vec_range)));

--- a/clients/gtest/stein_gtest.cpp
+++ b/clients/gtest/stein_gtest.cpp
@@ -15,8 +15,8 @@ typedef std::tuple<vector<int>, int> stein_tuple;
 
 // each size_range vector is a {N, ldz}
 
-// each vec_range is a {nev} 
-// Indicates the number of vectors to compute 
+// each vec_range is a {nev}
+// Indicates the number of vectors to compute
 // (vectors are always associated with the last nev eigenvalues)
 
 // case when N == 0 and nev == 5 will also execute the bad arguments test
@@ -39,12 +39,10 @@ const vector<int> vec_range = {5, 10, 15};
 const vector<vector<int>> large_matrix_size_range = {{192, 192}, {256, 270}, {300, 300}};
 const vector<int> large_vec_range = {25, 40, 65};
 
-
-
 Arguments stein_setup_arguments(stein_tuple tup)
 {
     Arguments arg;
-    
+
     vector<int> size = std::get<0>(tup);
     rocblas_int nev = std::get<1>(tup);
 
@@ -98,8 +96,10 @@ TEST_P(STEIN, __double_complex)
     run_tests<rocblas_double_complex>();
 }
 
-INSTANTIATE_TEST_SUITE_P(daily_lapack, STEIN, 
-                        Combine(ValuesIn(large_matrix_size_range), ValuesIn(large_vec_range)));
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         STEIN,
+                         Combine(ValuesIn(large_matrix_size_range), ValuesIn(large_vec_range)));
 
-INSTANTIATE_TEST_SUITE_P(checkin_lapack, STEIN, 
-                        Combine(ValuesIn(matrix_size_range), ValuesIn(vec_range)));
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         STEIN,
+                         Combine(ValuesIn(matrix_size_range), ValuesIn(vec_range)));

--- a/clients/include/testing_stein.hpp
+++ b/clients/include/testing_stein.hpp
@@ -202,8 +202,8 @@ void stein_getError(const rocblas_handle handle,
     std::vector<rocblas_int> iwork(liwork);
 
     // input data initialization
-    stein_initData<true, true, T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, hD, hE, hNev, hW,
-                                  hIblock, hIsplit);
+    stein_initData<true, true, T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, hD, hE, hNev,
+                                  hW, hIblock, hIsplit);
 
     // execute computations
     // GPU lapack
@@ -239,7 +239,7 @@ void stein_getError(const rocblas_handle handle,
 
         // need to implicitly test eigenvectors due to non-uniqueness of eigenvectors under scaling
 
-        // for each of the nev eigenvalues w_j, verify that the associated eigenvector is in the 
+        // for each of the nev eigenvalues w_j, verify that the associated eigenvector is in the
         // null space of (A - w_i * I)
         T alpha, t1, t2;
         for(int j = 0; j < hNev[0][0]; j++)
@@ -247,17 +247,17 @@ void stein_getError(const rocblas_handle handle,
             for(int i = 0; i < n; i++)
             {
                 alpha = hW[0][j] - hD[0][i];
-                hZ[0][i+j*ldz] = hZRes[0][i+j*ldz] * alpha;
+                hZ[0][i + j * ldz] = hZRes[0][i + j * ldz] * alpha;
             }
-            t1 = hZRes[0][j*ldz];
-            hZRes[0][j*ldz] = hE[0][0] * hZRes[0][1+j*ldz];
-            for(int i = 1; i < n-1; i++)
+            t1 = hZRes[0][j * ldz];
+            hZRes[0][j * ldz] = hE[0][0] * hZRes[0][1 + j * ldz];
+            for(int i = 1; i < n - 1; i++)
             {
-                t2 = hZRes[0][i+j*ldz];
-                hZRes[0][i+j*ldz] = hE[0][i-1] * t1 + hE[0][i] * hZRes[0][(i+1)+j*ldz];
+                t2 = hZRes[0][i + j * ldz];
+                hZRes[0][i + j * ldz] = hE[0][i - 1] * t1 + hE[0][i] * hZRes[0][(i + 1) + j * ldz];
                 t1 = t2;
             }
-            hZRes[0][(n-1)+j*ldz] = hE[0][n-2] * t1;
+            hZRes[0][(n - 1) + j * ldz] = hE[0][n - 2] * t1;
         }
 
         // error is then ||hZ - hZRes|| / ||hZ||
@@ -317,8 +317,8 @@ void stein_getPerfData(const rocblas_handle handle,
 
     if(!perf)
     {
-        stein_initData<true, false, T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, hD, hE, hNev,
-                                       hW, hIblock, hIsplit);
+        stein_initData<true, false, T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, hD, hE,
+                                       hNev, hW, hIblock, hIsplit);
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
@@ -327,14 +327,14 @@ void stein_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
-    stein_initData<true, false, T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, hD, hE, hNev, hW,
-                                   hIblock, hIsplit);
+    stein_initData<true, false, T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, hD, hE, hNev,
+                                   hW, hIblock, hIsplit);
 
     // cold calls
     for(int iter = 0; iter < 2; iter++)
     {
-        stein_initData<false, true, T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, hD, hE, hNev,
-                                       hW, hIblock, hIsplit);
+        stein_initData<false, true, T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, hD, hE,
+                                       hNev, hW, hIblock, hIsplit);
 
         CHECK_ROCBLAS_ERROR(rocsolver_stein(handle, n, dD.data(), dE.data(), dNev.data(), dW.data(),
                                             dIblock.data(), dIsplit.data(), dZ.data(), ldz,
@@ -354,8 +354,8 @@ void stein_getPerfData(const rocblas_handle handle,
 
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
-        stein_initData<false, true, T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, hD, hE, hNev,
-                                       hW, hIblock, hIsplit);
+        stein_initData<false, true, T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, hD, hE,
+                                       hNev, hW, hIblock, hIsplit);
 
         start = get_time_us_sync(stream);
         rocsolver_stein(handle, n, dD.data(), dE.data(), dNev.data(), dW.data(), dIblock.data(),
@@ -373,7 +373,7 @@ void testing_stein(Arguments& argus)
     // get arguments
     rocblas_local_handle handle;
     rocblas_int n = argus.get<rocblas_int>("n");
-    rocblas_int nev = argus.get<rocblas_int>("nev", n < 5 ? n : 5 );
+    rocblas_int nev = argus.get<rocblas_int>("nev", n < 5 ? n : 5);
     rocblas_int ldz = argus.get<rocblas_int>("ldz", n);
 
     rocblas_int hot_calls = argus.iters;
@@ -486,20 +486,20 @@ void testing_stein(Arguments& argus)
 
     // check computations
     if(argus.unit_check || argus.norm_check)
-        stein_getError<T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, dZ, ldz, dIfail, dInfo, hD,
-                          hE, hNev, hW, hIblock, hIsplit, hZ, hZRes, hIfail, hIfailRes, hInfo,
-                          hInfoRes, &max_error);
+        stein_getError<T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, dZ, ldz, dIfail,
+                          dInfo, hD, hE, hNev, hW, hIblock, hIsplit, hZ, hZRes, hIfail, hIfailRes,
+                          hInfo, hInfoRes, &max_error);
 
     // collect performance data
     if(argus.timing)
-        stein_getPerfData<T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, dZ, ldz, dIfail, dInfo,
-                             hD, hE, hNev, hW, hIblock, hIsplit, hZ, hIfail, hInfo, &gpu_time_used,
-                             &cpu_time_used, hot_calls, argus.profile, argus.perf);
+        stein_getPerfData<T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, dZ, ldz, dIfail,
+                             dInfo, hD, hE, hNev, hW, hIblock, hIsplit, hZ, hIfail, hInfo,
+                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.perf);
 
     // validate results for rocsolver-test
     // using 2 * n * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, 2*n);//2*n
+        ROCSOLVER_TEST_CHECK(T, max_error, 2 * n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/library/include/rocsolver-functions.h
+++ b/library/include/rocsolver-functions.h
@@ -3902,7 +3902,8 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zstedc(rocblas_handle handle,
 //! @}
 
 /*! @{
-    \brief STEIN computes a set of the eigenvectors of a symmetric tridiagonal matrix.
+    \brief STEIN computes the eigenvectors associated with a set of 
+    provided eigenvalues of a symmetric tridiagonal matrix.
 
     \details
     The eigenvectors of the symmetric tridiagonal matrix are computed using
@@ -3910,8 +3911,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zstedc(rocblas_handle handle,
 
     The matrix is not represented explicitly, but rather as the array of
     diagonal elements D and the array of symmetric off-diagonal elements E.
-    A subset of the matrix eigenvalues must be provided in the array W,
-    as returned by \ref rocsolver_sstebz "STEBZ".
+    The eigenvalues must be provided in the array W, as returned by \ref rocsolver_sstebz "STEBZ".
 
     @param[in]
     handle      rocblas_handle.
@@ -3925,29 +3925,29 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zstedc(rocblas_handle handle,
     E           pointer to real type. Array on the GPU of dimension n-1.\n
                 The off-diagonal elements of the tridiagonal matrix.
     @param[in]
-    nev         pointer to a rocblas_int on the GPU. nev <= n.\n
+    nev         pointer to a rocblas_int on the GPU. 0 <= nev <= n.\n
                 The number of provided eigenvalues, and the number of eigenvectors
                 to be computed.
     @param[in]
-    W           pointer to real type. Array on the GPU of dimension nev.\n
+    W           pointer to real type. Array on the GPU of dimension >= nev.\n
                 A subset of nev eigenvalues of the tridiagonal matrix, as returned
                 by \ref rocsolver_sstebz "STEBZ".
     @param[in]
-    inblock     pointer to rocblas_int. Array on the GPU of dimension n.\n
-                The submatrix indices corresponding to each eigenvalue, as
+    iblock      pointer to rocblas_int. Array on the GPU of dimension n.\n
+                The block indices corresponding to each eigenvalue, as
                 returned by \ref rocsolver_sstebz "STEBZ". If iblock[i] = k,
-                then eigenvalue W[i] belongs to the k-th submatrix from the top.
+                then eigenvalue W[i] belongs to the k-th block from the top.
     @param[in]
     isplit      pointer to rocblas_int. Array on the GPU of dimension n.\n
                 The splitting indices that divide the tridiagonal matrix into
-                submatrices, as returned by \ref rocsolver_sstebz "STEBZ".
-                The k-th submatrix stretches from the end of the (k-1)-th
-                submatrix (or the top left corner of the tridiagonal matrix,
-                in the case of the 1st submatrix) to the isplit[k]-th row/column.
+                diagonal blocks, as returned by \ref rocsolver_sstebz "STEBZ".
+                The k-th block stretches from the end of the (k-1)-th
+                block (or the top left corner of the tridiagonal matrix,
+                in the case of the 1st block) to the isplit[k]-th row/column.
     @param[out]
     Z           pointer to type. Array on the GPU of dimension ldz*nev.\n
                 On exit, contains the eigenvectors of the tridiagonal matrix
-                corresponding to the provided eigenvalues.
+                corresponding to the provided eigenvalues, stored by columns.
     @param[in]
     ldc         rocblas_int. ldz >= n.\n
                 Specifies the leading dimension of Z.
@@ -3959,8 +3959,9 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zstedc(rocblas_handle handle,
     @param[out]
     info        pointer to a rocblas_int on the GPU.\n
                 If info = 0, successful exit.
-                If info = i > 0, STEIN did not converge. i eigenvectors of the
-                matrix did not converge.
+                If info = i > 0, i eigenvectors did not converge; their indices are stored in
+                IFAIL.
+
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sstein(rocblas_handle handle,


### PR DESCRIPTION
In addition to the test coverage extension depicted in https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/393, 
I also changed the implicit test. I wanted to rule out any possible numerical artifacts introduced by the computations in the test. So, I am computing the backward error (i.e. verifying that any vector belongs to the null space of A-wI) with just simple arithmetic operations. Unfortunately, there are still failing tests in single precision and the error, as you will see, is not small. So, there is certainly something wrong in the algorithm implementation (my guess is that there is memory/workspace overlapping)... 

I also made some minor changes to the documentation. Mainly I just prefer to use "block" instead of "submatrix". Both terms are totally correct and mostly interchangeable, but  there is a subtle difference for some groups (specially people working with structured matrices): submatrix is mostly used in the context of matrix updates (rank updates) and thus it is expected to include at least one edge of the original matrix (i.e the first row or column or the last row or column), while a block is an arbitrary subset of rows and columns... ie. any submatrix is a block but not all blocks are submatrices. 
